### PR TITLE
Update ngram.c: powi() function

### DIFF
--- a/ngram.c
+++ b/ngram.c
@@ -36,8 +36,12 @@ void *malloc_check(size_t size, const char *file, int line) {
 size_t powi(int base, int exp) {
     // integer exponentiation utility
     size_t result = 1;
-    for (int i = 0; i < exp; i++) {
-        result *= base;
+    while(exp > 0){
+        if (exp & 1){
+          result *= base;
+        }
+        base *= base;
+        exp >>= 1;
     }
     return result;
 }


### PR DESCRIPTION
### summary of what I did

utilize how binary numbers work to cut down number of iterations in the for-loop of powi() function.

we now only have to do 'ceil(log(exp))' steps, instead of 'exp' steps in the for-loop of powi() function.

### details

If we represent 'exp' in binary numbers, one will soon find out that we don't need to accumulate the power to the 'base' in a linear fashion. 

For example, we want to calculate power(base = 2, exp = 5),
1. represent 'exp' in binary: 5 = 101 (binary) (assume exp always >= 0)
2. counting from right to left, from 0 to number of digits in 'exp', if the digit is '1', it means that it contributes to the result.

5 = 4(1) + 2(0) + 1(1) => result = power(2,4) * power(2,1) = 16*2 = 32

#### what if base < 0

- if exp is odd -> the result < 0. the fact that power(base,1), which is less than 0, appeared exactly once results the 'result' to be negative. result < 0 matches the case where exp is odd.
- similarly, if exp is even -> the result > 0, no power(base,1) appeared. 'result' will be greater than 0.

So, this works for base < 0 as well.

### test script

```c
#include<stdio.h>

// the original implementation
size_t powi(int base, int exp) {
    // integer exponentiation utility
    size_t result = 1;
    for (int i = 0; i < exp; i++) {
        result *= base;
    }
    return result;
}

// the modified one
size_t powi2(int base, int exp) {
    // integer exponentiation utility
    size_t result = 1;
    while(exp > 0){
        if (exp & 1){
          result *= base;
        }
        base *= base; // power up
        exp >>= 1; // check next bit of the exponent
    }
    return result;
}

int main()
{
  printf("compile succeeded!\n");
  // change the bound of 'base' and 'exp' here
  // so that it matches the scale in 'ngram.c'
  for(int base = 2; base < 10; base += 1)
  {
    for(int exp = 1; exp < 6; exp += 1)
    {
      // if the outputs are different, program will quit & print the numbers
      if (powi(base, exp) != powi2(base,exp))
      {
        printf("%d, %d\n", base, exp);
        return 0;
      }

    }
  }
  return 0;
}
```